### PR TITLE
Don't double-up on GitHub

### DIFF
--- a/draft-vvv-quic-namespaces.md
+++ b/draft-vvv-quic-namespaces.md
@@ -18,7 +18,7 @@ venue:
   type: Working Group
   mail: quic@ietf.org
   arch: https://example.com/WG
-  github: https://github.com/vasilvv/draft-vvv-quic-namespaces
+  github: vasilvv/draft-vvv-quic-namespaces
   #latest: https://example.com/LATEST
 
 author:


### PR DESCRIPTION
This displays as "https://github.com/https://github.com/vasilvv/draft-vvv-quic-namespaces"  Consider instead using `make update-venue` for this one.